### PR TITLE
Update CI job config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.android.tools.build:gradle:3.4.1'
         classpath 'com.novoda:bintray-release:0.9.1'
+        classpath 'com.novoda:gradle-build-properties-plugin:0.4.1'
     }
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'bintray-release'
-apply plugin: 'jacoco'
 apply plugin: 'com.novoda.build-properties'
 
 buildProperties {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,5 +1,35 @@
 apply plugin: 'com.android.library'
 apply plugin: 'bintray-release'
+apply plugin: 'jacoco'
+apply plugin: 'com.novoda.build-properties'
+
+buildProperties {
+    cli {
+        using(project)
+    }
+    bintray {
+        def bintrayCredentials = {
+            boolean isDryRun = cli['dryRun'].or(true).boolean
+            return isDryRun ?
+                    ['bintrayOrg': 'n/a', 'bintrayRepo': 'n/a', 'bintrayUser': 'n/a', 'bintrayKey': 'n/a'] :
+                    new File("${System.getenv('BINTRAY_PROPERTIES')}")
+        }
+        using(bintrayCredentials()).or(cli)
+        description = '''This should contain the following properties:
+                        - bintrayOrg: name of the Bintray organisation to deploy the artifacts to
+                        - bintrayRepo: name of the repo of the organisation to deploy the artifacts to
+                        - bintrayUser: name of the account used to deploy the artifacts
+                        - bintrayKey: API key of the account used to deploy the artifacts
+        '''.stripIndent()
+    }
+    publish {
+        def generateVersion = {
+            return version
+        }
+        using(['version': "${generateVersion()}"])
+                .or(buildProperties.bintray)
+    }
+}
 
 android {
     defaultConfig {
@@ -12,10 +42,13 @@ android {
 }
 
 publish {
-    userOrg = 'novoda'
-    repoName = 'maven'
+    userOrg = buildProperties.publish['bintrayOrg'].string
+    repoName = buildProperties.publish['bintrayRepo'].string
     groupId = 'com.novoda'
     artifactId = 'drop-cap'
+    version = buildProperties.publish['version'].string
+    bintrayUser = buildProperties.publish['bintrayUser'].string
+    bintrayKey = buildProperties.publish['bintrayKey'].string
     publishVersion = version
     uploadName = 'drop-cap'
     desc = 'This library can be used to create a DropCap in your app.'


### PR DESCRIPTION
### Problem 
Releasing this library is not possible because the job config is not pointing to our new bintray repo.

### Solution
Update the config to allow the job to execute successfully.