### PR TITLE
Remove Jetifier

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,1 @@
-android.enableJetifier=true
 android.useAndroidX=true


### PR DESCRIPTION
This library is already migrated to Android X but it uses Jetifier, as it is not necessary we can purge it. Fixes #7